### PR TITLE
Revamp dashboard and auth flows

### DIFF
--- a/lib/dashboard_page.dart
+++ b/lib/dashboard_page.dart
@@ -1,269 +1,698 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:pie_chart/pie_chart.dart';
+
+import 'expenses_page.dart';
+import 'history_page.dart';
 
 class DashboardPage extends StatefulWidget {
-  final String groupId; // Örn: "building8_flat3"
+  final String groupId;
   const DashboardPage({super.key, this.groupId = 'building8_flat3'});
 
   @override
   State<DashboardPage> createState() => _DashboardPageState();
 }
 
-class _DashboardPageState extends State<DashboardPage> {
+class _DashboardPageState extends State<DashboardPage>
+    with SingleTickerProviderStateMixin {
   final _auth = FirebaseAuth.instance;
+  late final TabController _tabController;
+  final _expensesKey = GlobalKey<ExpensesPageState>();
 
-  // UI renkleri
-  static const _trashColor = Color(0xFFFFC107);       // sarı
-  static const _kitchenColor = Color(0xFF42A5F5);     // mavi
-  static const _livingColor = Color(0xFF66BB6A);      // yeşil
-  static final _idleGrey = Colors.grey.shade300;
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+    _tabController.addListener(_handleTabChange);
+  }
 
-  // 1..13 odalar
-  final List<int> rooms = List<int>.generate(13, (i) => i + 1);
+  void _handleTabChange() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
 
-  // PieChart için sabit data (13 dilim, her biri 1)
-  late final Map<String, double> _dataMap = {
-    for (final r in rooms) 'Room $r': 1.0,
-  };
+  @override
+  void dispose() {
+    _tabController.removeListener(_handleTabChange);
+    _tabController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final docRef =
-        FirebaseFirestore.instance.collection('groups').doc(widget.groupId);
+    final docRef = FirebaseFirestore.instance.collection('groups').doc(widget.groupId);
 
     return StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
       stream: docRef.snapshots(),
       builder: (context, snap) {
         if (snap.hasError) {
-          return _scaffold(body: _centerText('Hata: ${snap.error}'));
+          return _statusScaffold('Hata: ${snap.error}');
         }
         if (!snap.hasData) {
-          return _scaffold(body: const Center(child: CircularProgressIndicator()));
+          return _statusScaffold(null);
         }
         final data = snap.data!.data();
         if (data == null) {
-          return _scaffold(body: _centerText('Grup bulunamadı: ${widget.groupId}'));
+          return _statusScaffold('Grup bulunamadı: ${widget.groupId}');
         }
 
-        // members: [{uid, roomNumber}, ...]
-        final members = List<Map<String, dynamic>>.from(
-          (data['members'] ?? []) as List,
+        final members = _parseMembers(data['members']);
+        final currentTasks = Map<String, dynamic>.from(data['currentTasks'] ?? {});
+        final user = _auth.currentUser;
+        final userRoom = _roomForUid(user?.uid, members);
+
+        final tasks = _buildTasks(currentTasks, members);
+
+        final roomNumbers = members
+            .map((m) => m.roomNumber)
+            .whereType<int>()
+            .toSet()
+            .toList()
+          ..sort();
+        if (roomNumbers.isEmpty) {
+          roomNumbers.addAll(List.generate(10, (i) => i + 1));
+        }
+
+        final overviewTab = _OverviewTab(
+          groupName: data['name'] as String? ?? 'FlatMate',
+          members: members,
+          yourEmail: user?.email ?? user?.uid ?? '-',
+          yourRoom: userRoom,
+          tasks: tasks,
+          historyStream: docRef
+              .collection('taskHistory')
+              .orderBy('createdAt', descending: true)
+              .limit(20)
+              .snapshots(),
         );
 
-        // currentTasks: {trash: (uid|room), kitchen: (uid|room), living_room: (uid|room)}
-        final Map<String, dynamic> currentTasks =
-            Map<String, dynamic>.from(data['currentTasks'] ?? {});
+        final expensesTab = ExpensesPage(
+          key: _expensesKey,
+          groupId: widget.groupId,
+          roomNumbers: roomNumbers,
+          embedded: true,
+        );
 
-        // yardımcı: uid -> oda
-        int? roomOfUid(String? uid) {
-          if (uid == null) return null;
-          final ix = members.indexWhere((m) => m['uid'] == uid);
-          if (ix == -1) return null;
-          final rn = (members[ix]['roomNumber'] as num?)?.toInt();
-          return rn;
-        }
+        final historyTab = TaskHistoryPage(
+          groupId: widget.groupId,
+          embedded: true,
+        );
 
-        // her görev için atanmış oda
-        int? roomForTask(String taskKey) {
-          final v = currentTasks[taskKey];
-          if (v == null) return null;
-          if (v is num) return v.toInt();
-          if (v is String) return roomOfUid(v);
-          return null;
-        }
+        final fab = _tabController.index == 1
+            ? FloatingActionButton.extended(
+                onPressed: () => _expensesKey.currentState?.openAddExpenseSheet(),
+                icon: const Icon(Icons.add),
+                label: const Text('Harcama ekle'),
+              )
+            : null;
 
-        final trashRoom = roomForTask('trash');
-        final kitchenRoom = roomForTask('kitchen');
-        final livingRoom = roomForTask('living_room');
+        final groupName = data['name'] as String? ?? 'FlatMate';
 
-        // PieChart renk listesi (13 dilim sırayla Room1..Room13)
-        final List<Color> colorList = rooms.map((r) {
-          if (r == trashRoom) return _trashColor;
-          if (r == kitchenRoom) return _kitchenColor;
-          if (r == livingRoom) return _livingColor;
-          return _idleGrey;
-        }).toList();
-
-        return _scaffold(
-          body: SingleChildScrollView(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
+        return Scaffold(
+          appBar: AppBar(
+            title: Row(
               children: [
-                // Grafik
-                PieChart(
-                  dataMap: _dataMap,
-                  chartType: ChartType.disc,
-                  colorList: colorList,
-                  chartLegendSpacing: 28,
-                  chartRadius: MediaQuery.of(context).size.width * 0.6,
-                  legendOptions: const LegendOptions(
-                    showLegends: false, // kendi legend'ımızı çiziyoruz
-                  ),
-                  chartValuesOptions: const ChartValuesOptions(
-                    showChartValues: false,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                _legendRow(trashRoom, kitchenRoom, livingRoom),
-
-                const SizedBox(height: 20),
-
-                // Görev kartları
-                _taskCard(
-                  title: 'trash',
-                  color: _trashColor,
-                  assignedRoom: trashRoom,
-                  onTake: () => _takeTask('trash'),
-                  onDone: () => _markDone('trash'),
-                ),
-                _taskCard(
-                  title: 'kitchen',
-                  color: _kitchenColor,
-                  assignedRoom: kitchenRoom,
-                  onTake: () => _takeTask('kitchen'),
-                  onDone: () => _markDone('kitchen'),
-                ),
-                _taskCard(
-                  title: 'living_room',
-                  color: _livingColor,
-                  assignedRoom: livingRoom,
-                  onTake: () => _takeTask('living_room'),
-                  onDone: () => _markDone('living_room'),
-                ),
-
-                const SizedBox(height: 12),
-
-                // Kim olduğunu göster
-                Center(
+                Image.asset('assets/loogo.png', height: 34),
+                const SizedBox(width: 12),
+                Flexible(
                   child: Text(
-                    'You: ${_auth.currentUser?.email ?? _auth.currentUser?.uid ?? '-'}',
-                    style: TextStyle(color: Colors.grey.shade700),
+                    groupName,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
               ],
             ),
+            actions: [
+              IconButton(
+                onPressed: _signOut,
+                tooltip: 'Çıkış yap',
+                icon: const Icon(Icons.logout),
+              ),
+            ],
+            bottom: TabBar(
+              controller: _tabController,
+              tabs: const [
+                Tab(icon: Icon(Icons.dashboard_outlined), text: 'Genel'),
+                Tab(icon: Icon(Icons.receipt_long_outlined), text: 'Giderler'),
+                Tab(icon: Icon(Icons.history), text: 'Tarihçe'),
+              ],
+            ),
+          ),
+          floatingActionButton: fab,
+          body: TabBarView(
+            controller: _tabController,
+            children: [
+              overviewTab,
+              expensesTab,
+              historyTab,
+            ],
           ),
         );
       },
     );
   }
 
-  // ---------- Firestore helpers ----------
+  List<_TaskTileData> _buildTasks(
+    Map<String, dynamic> currentTasks,
+    List<_Member> members,
+  ) {
+    final configs = const [
+      _TaskConfig(key: 'trash', title: 'Çöp', color: Color(0xFFFFC107)),
+      _TaskConfig(key: 'kitchen', title: 'Mutfak', color: Color(0xFF42A5F5)),
+      _TaskConfig(key: 'living_room', title: 'Salon', color: Color(0xFF66BB6A)),
+    ];
 
-  Future<void> _takeTask(String taskKey) async {
     final user = _auth.currentUser;
-    if (user == null) return;
-    final ref =
-        FirebaseFirestore.instance.collection('groups').doc(widget.groupId);
-    await ref.update({
-      'currentTasks.$taskKey': user.uid,
-      'completedTasks.$taskKey': false,
-      'updatedAt': FieldValue.serverTimestamp(),
-    });
+    final userRoom = _roomForUid(user?.uid, members);
+
+    return configs.map((config) {
+      final assignment = currentTasks[config.key];
+      final assignedRoom = _assignmentToRoom(assignment, members);
+      final assignedToYou = _isAssignmentForUser(assignment, user, userRoom);
+      final takenBySomeoneElse = assignment != null && !assignedToYou;
+
+      return _TaskTileData(
+        key: config.key,
+        title: config.title,
+        color: config.color,
+        assignedRoom: assignedRoom,
+        assignedToYou: assignedToYou,
+        takenByAnother: takenBySomeoneElse,
+        takeTask: () => _takeTask(
+          taskKey: config.key,
+          currentTasks: currentTasks,
+          members: members,
+        ),
+        completeTask: () => _markDone(
+          taskKey: config.key,
+          currentTasks: currentTasks,
+          members: members,
+        ),
+      );
+    }).toList();
   }
 
-  Future<void> _markDone(String taskKey) async {
+  Future<void> _takeTask({
+    required String taskKey,
+    required Map<String, dynamic> currentTasks,
+    required List<_Member> members,
+  }) async {
     final user = _auth.currentUser;
     if (user == null) return;
-    final ref =
-        FirebaseFirestore.instance.collection('groups').doc(widget.groupId);
 
-    // Basit "done" işareti + tarihçe girişi (proof fotoğrafını sonra ekliyoruz)
-    await ref.update({
-      'completedTasks.$taskKey': true,
-      'updatedAt': FieldValue.serverTimestamp(),
-    });
+    final assignment = currentTasks[taskKey];
+    final userRoom = _roomForUid(user.uid, members);
+    final alreadyYours = _isAssignmentForUser(assignment, user, userRoom);
+    if (alreadyYours) {
+      _showSnack('Görev zaten sende.');
+      return;
+    }
 
-    await ref.collection('taskHistory').add({
-      'task': taskKey,
-      'doneByUid': user.uid,
-      'doneByEmail': user.email,
-      'createdAt': FieldValue.serverTimestamp(),
-      // 'proofUrl': ...  (fotoğraf akışını sonra ekleyeceğiz)
-    });
+    if (assignment != null) {
+      final assignedRoom = _assignmentToRoom(assignment, members);
+      final who = assignedRoom == null ? 'başkası' : 'Oda $assignedRoom';
+      final confirm = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Görevi devral'),
+          content: Text('Görev şu anda $who tarafından üstlenilmiş. Devralmak istiyor musun?'),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Vazgeç')),
+            FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Devral')),
+          ],
+        ),
+      );
+      if (confirm != true) {
+        return;
+      }
+    }
+
+    final ref = FirebaseFirestore.instance.collection('groups').doc(widget.groupId);
+    try {
+      await ref.set({
+        'currentTasks.$taskKey': user.uid,
+        'completedTasks.$taskKey': false,
+        'updatedAt': FieldValue.serverTimestamp(),
+      }, SetOptions(merge: true));
+      _showSnack('Görev sana atandı.');
+    } catch (e) {
+      _showSnack('Görev alınamadı: $e');
+    }
   }
 
-  // ---------- UI bits ----------
+  Future<void> _markDone({
+    required String taskKey,
+    required Map<String, dynamic> currentTasks,
+    required List<_Member> members,
+  }) async {
+    final user = _auth.currentUser;
+    if (user == null) return;
 
-  Widget _taskCard({
-    required String title,
-    required Color color,
-    required int? assignedRoom,
-    required VoidCallback onTake,
-    required VoidCallback onDone,
-  }) {
-    final youText = assignedRoom == null ? 'Unknown' : 'Room $assignedRoom';
-    final isAssignedToYou = false; // atama uid bazlı kontrol istiyorsan genişlet
-    return Card(
-      elevation: 0,
-      color: color.withOpacity(0.12),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-      child: ListTile(
-        title: Text('$title → $youText',
-            style: const TextStyle(fontWeight: FontWeight.w600)),
-        trailing: Wrap(
-          spacing: 8,
+    final assignment = currentTasks[taskKey];
+    final userRoom = _roomForUid(user.uid, members);
+    final assignedToYou = _isAssignmentForUser(assignment, user, userRoom);
+    if (!assignedToYou) {
+      _showSnack('Görev senin üzerinde değil.');
+      return;
+    }
+
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Görev tamamlandı mı?'),
+        content: const Text('Bu görevi tamamladığını onaylıyor musun?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Hayır')),
+          FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Evet')),
+        ],
+      ),
+    );
+    if (confirm != true) {
+      return;
+    }
+
+    final ref = FirebaseFirestore.instance.collection('groups').doc(widget.groupId);
+    try {
+      await ref.set({
+        'completedTasks.$taskKey': true,
+        'currentTasks.$taskKey': user.uid,
+        'updatedAt': FieldValue.serverTimestamp(),
+      }, SetOptions(merge: true));
+
+      await ref.collection('taskHistory').add({
+        'task': taskKey,
+        'doneByUid': user.uid,
+        'doneByEmail': user.email,
+        'roomNumber': userRoom,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+
+      _showSnack('Harika! Görev tamamlandı.');
+    } catch (e) {
+      _showSnack('Görev işaretlenemedi: $e');
+    }
+  }
+
+  void _signOut() {
+    _auth.signOut();
+  }
+
+  void _showSnack(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  int? _roomForUid(String? uid, List<_Member> members) {
+    if (uid == null) return null;
+    for (final member in members) {
+      if (member.uid == uid) {
+        return member.roomNumber;
+      }
+    }
+    return null;
+  }
+
+  int? _assignmentToRoom(dynamic assignment, List<_Member> members) {
+    if (assignment == null) return null;
+    if (assignment is num) return assignment.toInt();
+    if (assignment is String) {
+      return _roomForUid(assignment, members);
+    }
+    return null;
+  }
+
+  bool _isAssignmentForUser(dynamic assignment, User? user, int? userRoom) {
+    if (assignment == null || user == null) return false;
+    if (assignment == user.uid) return true;
+    if (assignment is num && userRoom != null) {
+      return assignment.toInt() == userRoom;
+    }
+    if (assignment is String) {
+      return assignment == user.uid;
+    }
+    return false;
+  }
+
+  List<_Member> _parseMembers(dynamic raw) {
+    if (raw is! List) return const [];
+    final result = <_Member>[];
+    for (final item in raw) {
+      if (item is Map) {
+        final map = Map<String, dynamic>.from(item as Map);
+        result.add(
+          _Member(
+            uid: map['uid'] as String? ?? '',
+            roomNumber: (map['roomNumber'] as num?)?.toInt(),
+          ),
+        );
+      }
+    }
+    return result;
+  }
+
+  Widget _statusScaffold(String? message) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Row(
           children: [
-            OutlinedButton(
-              onPressed: onTake,
-              child: const Text('Take task'),
+            Image.asset('assets/loogo.png', height: 34),
+            const SizedBox(width: 12),
+            const Text('FlatMate'),
+          ],
+        ),
+      ),
+      body: message == null
+          ? const Center(child: CircularProgressIndicator())
+          : Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(message, textAlign: TextAlign.center),
+              ),
             ),
-            FilledButton(
-              onPressed: onDone,
-              child: const Text('Mark as done'),
+    );
+  }
+}
+
+class _OverviewTab extends StatelessWidget {
+  const _OverviewTab({
+    required this.groupName,
+    required this.members,
+    required this.yourEmail,
+    required this.yourRoom,
+    required this.tasks,
+    required this.historyStream,
+  });
+
+  final String groupName;
+  final List<_Member> members;
+  final String yourEmail;
+  final int? yourRoom;
+  final List<_TaskTileData> tasks;
+  final Stream<QuerySnapshot<Map<String, dynamic>>> historyStream;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final occupiedRooms = members
+        .map((m) => m.roomNumber)
+        .whereType<int>()
+        .toList()
+      ..sort();
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      children: [
+        _SummaryCard(
+          groupName: groupName,
+          yourEmail: yourEmail,
+          yourRoom: yourRoom,
+          occupiedRooms: occupiedRooms,
+        ),
+        const SizedBox(height: 20),
+        for (final task in tasks) ...[
+          _TaskCard(
+            data: task,
+            onTake: task.takeTask,
+            onDone: task.completeTask,
+          ),
+          const SizedBox(height: 12),
+        ],
+        const SizedBox(height: 8),
+        Text('Son aktiviteler', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        _RecentActivityList(stream: historyStream),
+      ],
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({
+    required this.groupName,
+    required this.yourEmail,
+    required this.yourRoom,
+    required this.occupiedRooms,
+  });
+
+  final String groupName;
+  final String yourEmail;
+  final int? yourRoom;
+  final List<int> occupiedRooms;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              groupName,
+              style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
             ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const Icon(Icons.person_pin_circle_outlined, size: 20),
+                const SizedBox(width: 8),
+                Expanded(child: Text('Sen: $yourEmail')),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                const Icon(Icons.meeting_room_outlined, size: 20),
+                const SizedBox(width: 8),
+                Text('Odan: ${yourRoom ?? '-'}'),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text('Oda dağılımı', style: theme.textTheme.labelLarge),
+            const SizedBox(height: 8),
+            if (occupiedRooms.isEmpty)
+              const Text('Henüz kayıtlı üye yok.')
+            else
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: occupiedRooms
+                    .map((room) => Chip(
+                          label: Text('Oda $room'),
+                          avatar: const Icon(Icons.bed_outlined, size: 18),
+                        ))
+                    .toList(),
+              ),
           ],
         ),
       ),
     );
   }
+}
 
-  Widget _legendRow(int? trashRoom, int? kitchenRoom, int? livingRoom) {
-    Widget chip(Color c, String label) => Container(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-          decoration: BoxDecoration(
-            color: c.withOpacity(0.2),
-            borderRadius: BorderRadius.circular(999),
-            border: Border.all(color: c.withOpacity(0.5)),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(width: 10, height: 10, decoration: BoxDecoration(color: c, shape: BoxShape.circle)),
-              const SizedBox(width: 8),
-              Text(label, style: const TextStyle(fontWeight: FontWeight.w600)),
-            ],
-          ),
-        );
+class _TaskCard extends StatelessWidget {
+  const _TaskCard({
+    required this.data,
+    required this.onTake,
+    required this.onDone,
+  });
 
-    return Wrap(
-      alignment: WrapAlignment.center,
-      spacing: 10,
-      runSpacing: 8,
-      children: [
-        chip(_trashColor, 'trash: ${trashRoom ?? '-'}'),
-        chip(_kitchenColor, 'kitchen: ${kitchenRoom ?? '-'}'),
-        chip(_livingColor, 'living: ${livingRoom ?? '-'}'),
-      ],
-    );
-  }
+  final _TaskTileData data;
+  final VoidCallback onTake;
+  final VoidCallback onDone;
 
-  Scaffold _scaffold({required Widget body}) {
-    return Scaffold(
-      // Sol üstte büyük logo
-      appBar: AppBar(
-        toolbarHeight: 64,
-        titleSpacing: 12,
-        centerTitle: false,
-        title: Image.asset('assets/loogo.png', height: 36),
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final assignedText =
+        data.assignedRoom == null ? 'Henüz atanmamış' : 'Oda ${data.assignedRoom}';
+
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      color: data.color.withOpacity(0.08),
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  data.title,
+                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                Container(
+                  width: 12,
+                  height: 12,
+                  decoration: BoxDecoration(color: data.color, shape: BoxShape.circle),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text('Atanan: $assignedText'),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: data.takenByAnother && !data.assignedToYou ? null : onTake,
+                    child: const Text('Görevi al'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton(
+                    onPressed: data.assignedToYou ? onDone : null,
+                    child: const Text('Tamamlandı'),
+                  ),
+                ),
+              ],
+            ),
+            if (data.assignedToYou)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  'Bu görev senin sorumluluğunda.',
+                  style: theme.textTheme.bodySmall?.copyWith(color: data.color),
+                ),
+              )
+            else if (data.takenByAnother)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  'Görev şu anda başka bir odada.',
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+          ],
+        ),
       ),
-      body: body,
     );
   }
+}
 
-  Widget _centerText(String s) =>
-      Center(child: Padding(padding: const EdgeInsets.all(24), child: Text(s)));
+class _RecentActivityList extends StatelessWidget {
+  const _RecentActivityList({required this.stream});
+
+  final Stream<QuerySnapshot<Map<String, dynamic>>> stream;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      elevation: 0,
+      child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: stream,
+        builder: (context, snap) {
+          if (snap.hasError) {
+            return _CardMessage('Tarihçe yüklenemedi: ${snap.error}');
+          }
+          if (!snap.hasData) {
+            return const Padding(
+              padding: EdgeInsets.all(24),
+              child: Center(child: CircularProgressIndicator()),
+            );
+          }
+          final docs = snap.data!.docs;
+          if (docs.isEmpty) {
+            return const _CardMessage('Henüz görev kaydı yok.');
+          }
+
+          return ListView.separated(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: docs.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final m = docs[index].data();
+              final task = (m['task'] ?? '').toString();
+              final room = (m['roomNumber'] ?? '').toString();
+              final email = (m['doneByEmail'] ?? '').toString();
+              final ts = m['createdAt'];
+              String timeLabel = '';
+              if (ts is Timestamp) {
+                timeLabel = ts.toDate().toLocal().toString().split('.').first;
+              }
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: theme.colorScheme.primaryContainer,
+                  child: Text(
+                    room == 'null' || room.isEmpty ? '?' : room,
+                    style: theme.textTheme.labelLarge,
+                  ),
+                ),
+                title: Text(task.isEmpty ? 'Görev' : task),
+                subtitle: Text([
+                  if (email.isNotEmpty) email,
+                  if (timeLabel.isNotEmpty) timeLabel,
+                ].join(' • ')),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CardMessage extends StatelessWidget {
+  const _CardMessage(this.message);
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class _TaskTileData {
+  const _TaskTileData({
+    required this.key,
+    required this.title,
+    required this.color,
+    required this.assignedRoom,
+    required this.assignedToYou,
+    required this.takenByAnother,
+    required this.takeTask,
+    required this.completeTask,
+  });
+
+  final String key;
+  final String title;
+  final Color color;
+  final int? assignedRoom;
+  final bool assignedToYou;
+  final bool takenByAnother;
+  final VoidCallback takeTask;
+  final VoidCallback completeTask;
+}
+
+class _TaskConfig {
+  const _TaskConfig({required this.key, required this.title, required this.color});
+
+  final String key;
+  final String title;
+  final Color color;
+}
+
+class _Member {
+  const _Member({required this.uid, required this.roomNumber});
+
+  final String uid;
+  final int? roomNumber;
 }

--- a/lib/expenses_page.dart
+++ b/lib/expenses_page.dart
@@ -4,18 +4,20 @@ import 'package:flutter/material.dart';
 
 class ExpensesPage extends StatefulWidget {
   final String groupId;
-  final List<int> roomNumbers; // örn: [1,2,3,4,...] – üyelerden doldur
+  final List<int> roomNumbers;
+  final bool embedded;
   const ExpensesPage({
     super.key,
     required this.groupId,
     required this.roomNumbers,
+    this.embedded = false,
   });
 
   @override
-  State<ExpensesPage> createState() => _ExpensesPageState();
+  ExpensesPageState createState() => ExpensesPageState();
 }
 
-class _ExpensesPageState extends State<ExpensesPage> {
+class ExpensesPageState extends State<ExpensesPage> {
   late final CollectionReference<Map<String, dynamic>> _col;
 
   @override
@@ -26,6 +28,8 @@ class _ExpensesPageState extends State<ExpensesPage> {
         .doc(widget.groupId)
         .collection('expenses');
   }
+
+  Future<void> openAddExpenseSheet() => _addExpenseDialog();
 
   Future<void> _addExpenseDialog() async {
     final descCtrl = TextEditingController();
@@ -41,22 +45,31 @@ class _ExpensesPageState extends State<ExpensesPage> {
       builder: (ctx) {
         return Padding(
           padding: EdgeInsets.only(
-            left: 16, right: 16, top: 12,
+            left: 16,
+            right: 16,
+            top: 12,
             bottom: MediaQuery.of(ctx).viewInsets.bottom + 16,
           ),
           child: Form(
             key: formKey,
             child: Column(
               mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                const Text('Yeni Harcama', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+                const Text(
+                  'Yeni harcama',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                  textAlign: TextAlign.center,
+                ),
                 const SizedBox(height: 12),
                 TextFormField(
                   controller: descCtrl,
                   decoration: const InputDecoration(
-                    labelText: 'Açıklama (örn. Bulaşık deterjanı)',
+                    labelText: 'Açıklama',
+                    hintText: 'Örn. Bulaşık deterjanı',
                     border: OutlineInputBorder(),
                   ),
+                  textCapitalization: TextCapitalization.sentences,
                   validator: (v) => (v == null || v.trim().isEmpty) ? 'Açıklama zorunlu' : null,
                 ),
                 const SizedBox(height: 12),
@@ -69,16 +82,16 @@ class _ExpensesPageState extends State<ExpensesPage> {
                   ),
                   validator: (v) {
                     if (v == null || v.trim().isEmpty) return 'Tutar zorunlu';
-                    final x = double.tryParse(v.replaceAll(',', '.'));
-                    if (x == null || x <= 0) return 'Geçerli bir tutar gir';
+                    final amount = double.tryParse(v.replaceAll(',', '.'));
+                    if (amount == null || amount <= 0) return 'Geçerli bir tutar gir';
                     return null;
                   },
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<int>(
                   value: buyerRoom,
-                  items: widget.roomNumbers.map((r) {
-                    return DropdownMenuItem(value: r, child: Text('Oda $r'));
+                  items: widget.roomNumbers.map((room) {
+                    return DropdownMenuItem(value: room, child: Text('Oda $room'));
                   }).toList(),
                   onChanged: (v) => buyerRoom = v,
                   decoration: const InputDecoration(
@@ -87,29 +100,26 @@ class _ExpensesPageState extends State<ExpensesPage> {
                   ),
                   validator: (v) => v == null ? 'Oda seç' : null,
                 ),
-                const SizedBox(height: 14),
-                SizedBox(
-                  width: double.infinity,
-                  child: FilledButton.icon(
-                    icon: const Icon(Icons.save),
-                    label: const Text('Ekle'),
-                    onPressed: () async {
-                      if (!(formKey.currentState?.validate() ?? false)) return;
-                      final user = FirebaseAuth.instance.currentUser;
-                      final amount = double.parse(priceCtrl.text.replaceAll(',', '.'));
+                const SizedBox(height: 16),
+                FilledButton.icon(
+                  onPressed: () async {
+                    if (!(formKey.currentState?.validate() ?? false)) return;
+                    final user = FirebaseAuth.instance.currentUser;
+                    final amount = double.parse(priceCtrl.text.replaceAll(',', '.'));
 
-                      await _col.add({
-                        'description': descCtrl.text.trim(),
-                        'amount': amount,
-                        'buyerRoom': buyerRoom,
-                        'createdAt': FieldValue.serverTimestamp(),
-                        'createdByUid': user?.uid,
-                        'createdByEmail': user?.email,
-                      });
+                    await _col.add({
+                      'description': descCtrl.text.trim(),
+                      'amount': amount,
+                      'buyerRoom': buyerRoom,
+                      'createdAt': FieldValue.serverTimestamp(),
+                      'createdByUid': user?.uid,
+                      'createdByEmail': user?.email,
+                    });
 
-                      if (mounted) Navigator.pop(ctx);
-                    },
-                  ),
+                    if (mounted) Navigator.pop(ctx);
+                  },
+                  icon: const Icon(Icons.save),
+                  label: const Text('Kaydet'),
                 ),
               ],
             ),
@@ -122,7 +132,7 @@ class _ExpensesPageState extends State<ExpensesPage> {
   Future<void> _deleteExpense(String docId) async {
     final ok = await showDialog<bool>(
       context: context,
-      builder: (_) => AlertDialog(
+      builder: (context) => AlertDialog(
         title: const Text('Silinsin mi?'),
         content: const Text('Bu harcamayı silmek istediğine emin misin?'),
         actions: [
@@ -138,7 +148,6 @@ class _ExpensesPageState extends State<ExpensesPage> {
 
   @override
   Widget build(BuildContext context) {
-    // createdAt yoksa orderBy patlamasın diye küçük güvenlik:
     final baseQuery = _col;
     return FutureBuilder<bool>(
       future: _hasCreatedAt(baseQuery),
@@ -148,114 +157,115 @@ class _ExpensesPageState extends State<ExpensesPage> {
             ? baseQuery.orderBy('createdAt', descending: true).limit(200)
             : baseQuery.limit(200);
 
+        final content = _buildContent(q);
+
+        if (widget.embedded) {
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(12, 16, 12, 24),
+            child: content,
+          );
+        }
+
         return Scaffold(
           appBar: AppBar(
             titleSpacing: 0,
             title: Row(
               children: [
-                // Minimal logo
                 Image.asset('assets/loogo.png', height: 28),
                 const SizedBox(width: 8),
-                const Text('Expenses'),
+                const Text('Giderler'),
               ],
             ),
           ),
           floatingActionButton: FloatingActionButton.extended(
             onPressed: _addExpenseDialog,
             icon: const Icon(Icons.add),
-            label: const Text('Ekle'),
+            label: const Text('Harcama ekle'),
           ),
-          body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-            stream: q.snapshots(),
-            builder: (context, snap) {
-              if (snap.hasError) {
-                return Center(child: Text('Hata: ${snap.error}'));
-              }
-              if (!snap.hasData) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              final docs = snap.data!.docs;
-              if (docs.isEmpty) {
-                return const Center(child: Text('Henüz harcama yok.'));
-              }
+          body: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
+            child: content,
+          ),
+        );
+      },
+    );
+  }
 
-              // Toplam ve oda bazlı toplam
-              final totalsByRoom = <int, double>{};
-              double grandTotal = 0;
-              for (final d in docs) {
-                final m = d.data();
-                final amount = (m['amount'] as num?)?.toDouble() ?? 0;
-                final room = (m['buyerRoom'] as num?)?.toInt();
-                grandTotal += amount;
-                if (room != null) {
-                  totalsByRoom.update(room, (v) => v + amount, ifAbsent: () => amount);
-                }
-              }
+  Widget _buildContent(Query<Map<String, dynamic>> q) {
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: q.snapshots(),
+      builder: (context, snap) {
+        if (snap.hasError) {
+          return Center(child: Text('Hata: ${snap.error}'));
+        }
+        if (!snap.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final docs = snap.data!.docs;
+        if (docs.isEmpty) {
+          return const _EmptyExpensesState();
+        }
 
-              return Column(
-                children: [
-                  // Üstte küçük toplam özet barı
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-                    child: Row(
+        final totalsByRoom = <int, double>{};
+        double grandTotal = 0;
+        for (final d in docs) {
+          final m = d.data();
+          final amount = (m['amount'] as num?)?.toDouble() ?? 0;
+          final room = (m['buyerRoom'] as num?)?.toInt();
+          grandTotal += amount;
+          if (room != null) {
+            totalsByRoom.update(room, (value) => value + amount, ifAbsent: () => amount);
+          }
+        }
+
+        return Column(
+          children: [
+            _ExpensesSummary(
+              grandTotal: grandTotal,
+              totalsByRoom: totalsByRoom,
+              rooms: widget.roomNumbers,
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: ListView.separated(
+                itemCount: docs.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (context, index) {
+                  final doc = docs[index];
+                  final m = doc.data();
+                  final amount = (m['amount'] as num?)?.toDouble() ?? 0;
+                  final desc = (m['description'] as String?) ?? '';
+                  final room = (m['buyerRoom'] as num?)?.toInt();
+                  final email = (m['createdByEmail'] as String?) ?? '';
+                  final ts = (m['createdAt'] as Timestamp?)?.toDate();
+                  final timeStr = ts == null ? '' : ts.toLocal().toString().split('.').first;
+
+                  return ListTile(
+                    leading: CircleAvatar(
+                      child: Text(room == null ? '?' : room.toString()),
+                    ),
+                    title: Text(desc, maxLines: 1, overflow: TextOverflow.ellipsis),
+                    subtitle: Text([
+                      if (email.isNotEmpty) email,
+                      if (timeStr.isNotEmpty) timeStr,
+                    ].join(' • ')),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
-                        Text('Toplam: ₺${grandTotal.toStringAsFixed(2)}',
+                        Text('₺${amount.toStringAsFixed(2)}',
                             style: const TextStyle(fontWeight: FontWeight.w600)),
-                        const Spacer(),
-                        // İlk 3 odayı kısaca göster
-                        Wrap(
-                          spacing: 12,
-                          children: widget.roomNumbers.take(3).map((r) {
-                            final t = totalsByRoom[r] ?? 0;
-                            return Text('Oda $r: ₺${t.toStringAsFixed(0)}');
-                          }).toList(),
+                        IconButton(
+                          icon: const Icon(Icons.delete_outline),
+                          onPressed: () => _deleteExpense(doc.id),
+                          tooltip: 'Sil',
                         ),
                       ],
                     ),
-                  ),
-                  const Divider(height: 1),
-                  Expanded(
-                    child: ListView.separated(
-                      itemCount: docs.length,
-                      separatorBuilder: (_, __) => const Divider(height: 1),
-                      itemBuilder: (_, i) {
-                        final doc = docs[i];
-                        final m = doc.data();
-                        final amount = (m['amount'] as num?)?.toDouble() ?? 0;
-                        final desc = (m['description'] as String?) ?? '';
-                        final room = (m['buyerRoom'] as num?)?.toInt();
-                        final email = (m['createdByEmail'] as String?) ?? '';
-                        final ts = (m['createdAt'] as Timestamp?)?.toDate();
-                        final timeStr = ts == null
-                            ? ''
-                            : '${ts.toLocal()}'.split('.').first;
-
-                        return ListTile(
-                          leading: CircleAvatar(
-                            child: Text(room == null ? '?' : room.toString()),
-                          ),
-                          title: Text(desc, maxLines: 1, overflow: TextOverflow.ellipsis),
-                          subtitle: Text('$email  •  $timeStr'),
-                          trailing: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text('₺${amount.toStringAsFixed(2)}',
-                                  style: const TextStyle(fontWeight: FontWeight.w600)),
-                              IconButton(
-                                icon: const Icon(Icons.delete_outline),
-                                onPressed: () => _deleteExpense(doc.id),
-                                tooltip: 'Sil',
-                              ),
-                            ],
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                ],
-              );
-            },
-          ),
+                  );
+                },
+              ),
+            ),
+          ],
         );
       },
     );
@@ -270,5 +280,69 @@ class _ExpensesPageState extends State<ExpensesPage> {
     } catch (_) {
       return false;
     }
+  }
+}
+
+class _ExpensesSummary extends StatelessWidget {
+  const _ExpensesSummary({
+    required this.grandTotal,
+    required this.totalsByRoom,
+    required this.rooms,
+  });
+
+  final double grandTotal;
+  final Map<int, double> totalsByRoom;
+  final List<int> rooms;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final visibleRooms = rooms.take(4).toList();
+
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Toplam: ₺${grandTotal.toStringAsFixed(2)}',
+                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              runSpacing: 4,
+              children: visibleRooms.map((room) {
+                final amount = totalsByRoom[room] ?? 0;
+                return Chip(
+                  label: Text('Oda $room • ₺${amount.toStringAsFixed(0)}'),
+                );
+              }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyExpensesState extends StatelessWidget {
+  const _EmptyExpensesState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          Icon(Icons.receipt_long_outlined, size: 48),
+          SizedBox(height: 12),
+          Text('Henüz harcama eklenmemiş.'),
+          SizedBox(height: 4),
+          Text('Sağ alttaki butonla ilk harcamanı kaydet.'),
+        ],
+      ),
+    );
   }
 }

--- a/lib/history_page.dart
+++ b/lib/history_page.dart
@@ -1,10 +1,10 @@
-// lib/history_page.dart
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 class TaskHistoryPage extends StatelessWidget {
   final String groupId;
-  const TaskHistoryPage({super.key, required this.groupId});
+  final bool embedded;
+  const TaskHistoryPage({super.key, required this.groupId, this.embedded = false});
 
   @override
   Widget build(BuildContext context) {
@@ -26,79 +26,21 @@ class TaskHistoryPage extends StatelessWidget {
             ? baseQuery.orderBy('createdAt', descending: true).limit(100)
             : baseQuery.limit(100);
 
-        return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-          stream: query.snapshots(),
-          builder: (context, snap) {
-            if (snap.hasError) {
-              return Scaffold(
-                appBar: AppBar(title: const Text('Task History')),
-                body: Center(child: Text('Hata: ${snap.error}')),
-              );
-            }
-            if (!snap.hasData) {
-              return Scaffold(
-                appBar: AppBar(title: const Text('Task History')),
-                body: const Center(child: CircularProgressIndicator()),
-              );
-            }
+        final content = _HistoryList(query: query);
 
-            final docs = snap.data!.docs;
-            if (docs.isEmpty) {
-              return Scaffold(
-                appBar: AppBar(title: const Text('Task History')),
-                body: const Center(child: Text('Henüz tarihçe yok.')),
-              );
-            }
+        if (embedded) {
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(12, 16, 12, 24),
+            child: content,
+          );
+        }
 
-            return Scaffold(
-              appBar: AppBar(title: const Text('Task History')),
-              body: ListView.separated(
-                padding: const EdgeInsets.all(12),
-                itemCount: docs.length,
-                separatorBuilder: (_, __) => const Divider(height: 1),
-                itemBuilder: (_, i) {
-                  final d = docs[i].data();
-                  final task = (d['task'] ?? 'task').toString();
-                  final room = (d['roomNumber'] ?? '?').toString();
-                  final by = (d['doneByEmail'] ?? d['doneBy'] ?? '').toString();
-                  final proof = d['proofUrl'] as String?;
-                  final ts = d['createdAt'];
-                  final timeStr = ts is Timestamp
-                      ? ts.toDate().toLocal().toString().split('.').first
-                      : '';
-
-                  return ListTile(
-                    leading: _ProofThumb(url: proof),
-                    title: Text('$task • Room $room'),
-                    subtitle: Text([by, timeStr].where((e) => e.isNotEmpty).join('  •  ')),
-                    onTap: proof != null
-                        ? () => showDialog(
-                              context: context,
-                              builder: (_) => Dialog(
-                                child: InteractiveViewer(
-                                  child: Image.network(
-                                    proof,
-                                    fit: BoxFit.contain,
-                                    loadingBuilder: (c, w, p) => p == null
-                                        ? w
-                                        : const SizedBox(
-                                            height: 240,
-                                            child: Center(child: CircularProgressIndicator()),
-                                          ),
-                                    errorBuilder: (c, e, s) => const Padding(
-                                      padding: EdgeInsets.all(24),
-                                      child: Text('Görsel yüklenemedi.'),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            )
-                        : null,
-                  );
-                },
-              ),
-            );
-          },
+        return Scaffold(
+          appBar: AppBar(title: const Text('Task History')),
+          body: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            child: content,
+          ),
         );
       },
     );
@@ -118,9 +60,88 @@ class TaskHistoryPage extends StatelessWidget {
   }
 }
 
+class _HistoryList extends StatelessWidget {
+  const _HistoryList({required this.query});
+
+  final Query<Map<String, dynamic>> query;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: query.snapshots(),
+      builder: (context, snap) {
+        if (snap.hasError) {
+          return Center(child: Text('Hata: ${snap.error}'));
+        }
+        if (!snap.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final docs = snap.data!.docs;
+        if (docs.isEmpty) {
+          return const Center(child: Text('Henüz tarihçe yok.'));
+        }
+
+        return Card(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          elevation: 0,
+          child: ListView.separated(
+            padding: const EdgeInsets.all(12),
+            itemCount: docs.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (_, i) {
+              final d = docs[i].data();
+              final task = (d['task'] ?? 'task').toString();
+              final room = (d['roomNumber'] ?? '?').toString();
+              final by = (d['doneByEmail'] ?? d['doneBy'] ?? '').toString();
+              final proof = d['proofUrl'] as String?;
+              final ts = d['createdAt'];
+              final timeStr = ts is Timestamp
+                  ? ts.toDate().toLocal().toString().split('.').first
+                  : '';
+
+              return ListTile(
+                leading: _ProofThumb(url: proof),
+                title: Text('$task • Oda $room'),
+                subtitle: Text([
+                  if (by.isNotEmpty) by,
+                  if (timeStr.isNotEmpty) timeStr,
+                ].join(' • ')),
+                onTap: proof != null
+                    ? () => showDialog(
+                          context: context,
+                          builder: (_) => Dialog(
+                            child: InteractiveViewer(
+                              child: Image.network(
+                                proof,
+                                fit: BoxFit.contain,
+                                loadingBuilder: (c, w, p) => p == null
+                                    ? w
+                                    : const SizedBox(
+                                        height: 240,
+                                        child: Center(child: CircularProgressIndicator()),
+                                      ),
+                                errorBuilder: (c, e, s) => const Padding(
+                                  padding: EdgeInsets.all(24),
+                                  child: Text('Görsel yüklenemedi.'),
+                                ),
+                              ),
+                            ),
+                          ),
+                        )
+                    : null,
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
 class _ProofThumb extends StatelessWidget {
-  final String? url;
   const _ProofThumb({this.url});
+  final String? url;
 
   @override
   Widget build(BuildContext context) {
@@ -150,5 +171,5 @@ class _ProofThumb extends StatelessWidget {
         ),
       ),
     );
-    }
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+
 import 'firebase_options.dart';
 import 'login_page.dart';
 import 'dashboard_page.dart';
@@ -18,9 +19,25 @@ class FlatMateApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = ColorScheme.fromSeed(seedColor: Colors.teal);
+
     return MaterialApp(
       title: 'FlatMate',
-      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.teal),
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: colorScheme,
+        scaffoldBackgroundColor: colorScheme.surface,
+        snackBarTheme: SnackBarThemeData(
+          backgroundColor: colorScheme.primaryContainer,
+          contentTextStyle: TextStyle(
+            color: colorScheme.onPrimaryContainer,
+            fontWeight: FontWeight.w600,
+          ),
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        ),
+        appBarTheme: const AppBarTheme(centerTitle: false),
+      ),
       debugShowCheckedModeBanner: false,
       home: StreamBuilder<User?>(
         stream: FirebaseAuth.instance.authStateChanges(),

--- a/lib/widgets/auth_shell.dart
+++ b/lib/widgets/auth_shell.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+/// Shared glassmorphism-style background used by the auth screens.
+class AuthShell extends StatelessWidget {
+  const AuthShell({
+    super.key,
+    required this.child,
+    this.maxWidth = 480,
+    this.padding = const EdgeInsets.symmetric(horizontal: 24, vertical: 28),
+  });
+
+  final Widget child;
+  final double maxWidth;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF2E335A), Color(0xFF1C1B33)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(maxWidth: maxWidth),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(26),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.06),
+                      borderRadius: BorderRadius.circular(26),
+                      border: Border.all(color: Colors.white.withOpacity(0.16)),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.28),
+                          blurRadius: 32,
+                          offset: const Offset(0, 20),
+                        ),
+                      ],
+                    ),
+                    child: DefaultTextStyle.merge(
+                      style: theme.textTheme.bodyMedium?.copyWith(color: Colors.white),
+                      child: IconTheme.merge(
+                        data: const IconThemeData(color: Colors.white70),
+                        child: Padding(
+                          padding: padding,
+                          child: child,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the app theme and add a shared glassmorphism auth shell for sign-in/up screens
- rebuild the login and register forms with validation, autofill, and clearer user messaging
- redesign the dashboard into a tabbed layout with integrated expenses/history views and improved task actions

## Testing
- `flutter test` *(fails: flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d548e7038c832fad00f8f842b7c39f