### PR TITLE
Translate UI copy to English

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -11,15 +11,15 @@ Future<void> bootstrapGroup({
 
   final groupRef = FirebaseFirestore.instance.collection('groups').doc(groupId);
 
-  // 1) GRUBU OKUMADAN OLUŞTUR / MERGE ET
+  // 1) Create or merge the group without reading it.
   await groupRef.set({
     'name': groupName,
     'createdBy': uid,
     'createdAt': FieldValue.serverTimestamp(),
     'rotationStart': {'trash': 1, 'living_room': 5, 'kitchen': 10},
-  }, SetOptions(merge: true)); // <-- okuma yok, direkt yaz
+  }, SetOptions(merge: true)); // <-- no read, write directly
 
-  // 2) KENDİNİ ÜYE OLARAK EKLE (bu yazma kurallara göre serbest)
+  // 2) Add yourself as a member (allowed by the write rules).
   final memberRef = groupRef.collection('members').doc(uid);
   await memberRef.set({
     'roomNumber': 1,
@@ -27,10 +27,10 @@ Future<void> bootstrapGroup({
     'joinedAt': FieldValue.serverTimestamp(),
   }, SetOptions(merge: true));
 
-  // 3) ARTIK ÜYESİN → TASKS OLUŞTUR
+  // 3) You are now a member -> create tasks.
   final tasksRef = groupRef.collection('tasks');
 
-  // tek tek merge ile yaz (varsa üstüne yazmaz, yoksa oluşturur)
+  // Write each doc with merge (no overwrite if present, creates if missing).
   await tasksRef.doc('trash').set({
     'name': 'trash',
     'assignedRoomNumber': 1,

--- a/lib/dashboard_page.dart
+++ b/lib/dashboard_page.dart
@@ -47,14 +47,14 @@ class _DashboardPageState extends State<DashboardPage>
       stream: docRef.snapshots(),
       builder: (context, snap) {
         if (snap.hasError) {
-          return _statusScaffold('Hata: ${snap.error}');
+          return _statusScaffold('Error: ${snap.error}');
         }
         if (!snap.hasData) {
           return _statusScaffold(null);
         }
         final data = snap.data!.data();
         if (data == null) {
-          return _statusScaffold('Grup bulunamadı: ${widget.groupId}');
+          return _statusScaffold('Group not found: ${widget.groupId}');
         }
 
         final members = _parseMembers(data['members']);
@@ -103,7 +103,7 @@ class _DashboardPageState extends State<DashboardPage>
             ? FloatingActionButton.extended(
                 onPressed: () => _expensesKey.currentState?.openAddExpenseSheet(),
                 icon: const Icon(Icons.add),
-                label: const Text('Harcama ekle'),
+                label: const Text('Add expense'),
               )
             : null;
 
@@ -126,16 +126,16 @@ class _DashboardPageState extends State<DashboardPage>
             actions: [
               IconButton(
                 onPressed: _signOut,
-                tooltip: 'Çıkış yap',
+                tooltip: 'Sign out',
                 icon: const Icon(Icons.logout),
               ),
             ],
             bottom: TabBar(
               controller: _tabController,
               tabs: const [
-                Tab(icon: Icon(Icons.dashboard_outlined), text: 'Genel'),
-                Tab(icon: Icon(Icons.receipt_long_outlined), text: 'Giderler'),
-                Tab(icon: Icon(Icons.history), text: 'Tarihçe'),
+                Tab(icon: Icon(Icons.dashboard_outlined), text: 'Overview'),
+                Tab(icon: Icon(Icons.receipt_long_outlined), text: 'Expenses'),
+                Tab(icon: Icon(Icons.history), text: 'History'),
               ],
             ),
           ),
@@ -158,9 +158,9 @@ class _DashboardPageState extends State<DashboardPage>
     List<_Member> members,
   ) {
     final configs = const [
-      _TaskConfig(key: 'trash', title: 'Çöp', color: Color(0xFFFFC107)),
-      _TaskConfig(key: 'kitchen', title: 'Mutfak', color: Color(0xFF42A5F5)),
-      _TaskConfig(key: 'living_room', title: 'Salon', color: Color(0xFF66BB6A)),
+      _TaskConfig(key: 'trash', title: 'Trash', color: Color(0xFFFFC107)),
+      _TaskConfig(key: 'kitchen', title: 'Kitchen', color: Color(0xFF42A5F5)),
+      _TaskConfig(key: 'living_room', title: 'Living room', color: Color(0xFF66BB6A)),
     ];
 
     final user = _auth.currentUser;
@@ -205,21 +205,21 @@ class _DashboardPageState extends State<DashboardPage>
     final userRoom = _roomForUid(user.uid, members);
     final alreadyYours = _isAssignmentForUser(assignment, user, userRoom);
     if (alreadyYours) {
-      _showSnack('Görev zaten sende.');
+      _showSnack('This task is already assigned to you.');
       return;
     }
 
     if (assignment != null) {
       final assignedRoom = _assignmentToRoom(assignment, members);
-      final who = assignedRoom == null ? 'başkası' : 'Oda $assignedRoom';
+      final who = assignedRoom == null ? 'someone else' : 'Room $assignedRoom';
       final confirm = await showDialog<bool>(
         context: context,
         builder: (context) => AlertDialog(
-          title: const Text('Görevi devral'),
-          content: Text('Görev şu anda $who tarafından üstlenilmiş. Devralmak istiyor musun?'),
+          title: const Text('Take over task?'),
+          content: Text('This task is currently taken by $who. Do you want to take it?'),
           actions: [
-            TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Vazgeç')),
-            FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Devral')),
+            TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
+            FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Take over')),
           ],
         ),
       );
@@ -235,9 +235,9 @@ class _DashboardPageState extends State<DashboardPage>
         'completedTasks.$taskKey': false,
         'updatedAt': FieldValue.serverTimestamp(),
       }, SetOptions(merge: true));
-      _showSnack('Görev sana atandı.');
+      _showSnack('Task assigned to you.');
     } catch (e) {
-      _showSnack('Görev alınamadı: $e');
+      _showSnack('Could not take task: $e');
     }
   }
 
@@ -253,18 +253,18 @@ class _DashboardPageState extends State<DashboardPage>
     final userRoom = _roomForUid(user.uid, members);
     final assignedToYou = _isAssignmentForUser(assignment, user, userRoom);
     if (!assignedToYou) {
-      _showSnack('Görev senin üzerinde değil.');
+      _showSnack('This task is not assigned to you.');
       return;
     }
 
     final confirm = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Görev tamamlandı mı?'),
-        content: const Text('Bu görevi tamamladığını onaylıyor musun?'),
+        title: const Text('Mark task as done?'),
+        content: const Text('Are you sure you completed this task?'),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Hayır')),
-          FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Evet')),
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('No')),
+          FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Yes')),
         ],
       ),
     );
@@ -288,9 +288,9 @@ class _DashboardPageState extends State<DashboardPage>
         'createdAt': FieldValue.serverTimestamp(),
       });
 
-      _showSnack('Harika! Görev tamamlandı.');
+      _showSnack('Nice! Task completed.');
     } catch (e) {
-      _showSnack('Görev işaretlenemedi: $e');
+      _showSnack('Could not mark task: $e');
     }
   }
 
@@ -419,7 +419,7 @@ class _OverviewTab extends StatelessWidget {
           const SizedBox(height: 12),
         ],
         const SizedBox(height: 8),
-        Text('Son aktiviteler', style: theme.textTheme.titleMedium),
+        Text('Recent activity', style: theme.textTheme.titleMedium),
         const SizedBox(height: 8),
         _RecentActivityList(stream: historyStream),
       ],
@@ -460,7 +460,7 @@ class _SummaryCard extends StatelessWidget {
               children: [
                 const Icon(Icons.person_pin_circle_outlined, size: 20),
                 const SizedBox(width: 8),
-                Expanded(child: Text('Sen: $yourEmail')),
+                Expanded(child: Text('You: $yourEmail')),
               ],
             ),
             const SizedBox(height: 8),
@@ -468,21 +468,21 @@ class _SummaryCard extends StatelessWidget {
               children: [
                 const Icon(Icons.meeting_room_outlined, size: 20),
                 const SizedBox(width: 8),
-                Text('Odan: ${yourRoom ?? '-'}'),
+                Text('Your room: ${yourRoom ?? '-'}'),
               ],
             ),
             const SizedBox(height: 16),
-            Text('Oda dağılımı', style: theme.textTheme.labelLarge),
+            Text('Room allocation', style: theme.textTheme.labelLarge),
             const SizedBox(height: 8),
             if (occupiedRooms.isEmpty)
-              const Text('Henüz kayıtlı üye yok.')
+              const Text('No registered members yet.')
             else
               Wrap(
                 spacing: 8,
                 runSpacing: 8,
                 children: occupiedRooms
                     .map((room) => Chip(
-                          label: Text('Oda $room'),
+                          label: Text('Room $room'),
                           avatar: const Icon(Icons.bed_outlined, size: 18),
                         ))
                     .toList(),
@@ -509,7 +509,7 @@ class _TaskCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final assignedText =
-        data.assignedRoom == null ? 'Henüz atanmamış' : 'Oda ${data.assignedRoom}';
+        data.assignedRoom == null ? 'Unassigned' : 'Room ${data.assignedRoom}';
 
     return Card(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
@@ -535,21 +535,21 @@ class _TaskCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 8),
-            Text('Atanan: $assignedText'),
+            Text('Assigned: $assignedText'),
             const SizedBox(height: 12),
             Row(
               children: [
                 Expanded(
                   child: OutlinedButton(
                     onPressed: data.takenByAnother && !data.assignedToYou ? null : onTake,
-                    child: const Text('Görevi al'),
+                    child: const Text('Take task'),
                   ),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
                   child: FilledButton(
                     onPressed: data.assignedToYou ? onDone : null,
-                    child: const Text('Tamamlandı'),
+                    child: const Text('Completed'),
                   ),
                 ),
               ],
@@ -558,7 +558,7 @@ class _TaskCard extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Text(
-                  'Bu görev senin sorumluluğunda.',
+                  'This task is your responsibility.',
                   style: theme.textTheme.bodySmall?.copyWith(color: data.color),
                 ),
               )
@@ -566,7 +566,7 @@ class _TaskCard extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Text(
-                  'Görev şu anda başka bir odada.',
+                  'This task is currently assigned to another room.',
                   style: theme.textTheme.bodySmall,
                 ),
               ),
@@ -592,7 +592,7 @@ class _RecentActivityList extends StatelessWidget {
         stream: stream,
         builder: (context, snap) {
           if (snap.hasError) {
-            return _CardMessage('Tarihçe yüklenemedi: ${snap.error}');
+            return _CardMessage('History failed to load: ${snap.error}');
           }
           if (!snap.hasData) {
             return const Padding(
@@ -602,7 +602,7 @@ class _RecentActivityList extends StatelessWidget {
           }
           final docs = snap.data!.docs;
           if (docs.isEmpty) {
-            return const _CardMessage('Henüz görev kaydı yok.');
+            return const _CardMessage('No task history yet.');
           }
 
           return ListView.separated(
@@ -628,7 +628,7 @@ class _RecentActivityList extends StatelessWidget {
                     style: theme.textTheme.labelLarge,
                   ),
                 ),
-                title: Text(task.isEmpty ? 'Görev' : task),
+                title: Text(task.isEmpty ? 'Task' : task),
                 subtitle: Text([
                   if (email.isNotEmpty) email,
                   if (timeLabel.isNotEmpty) timeLabel,

--- a/lib/expenses_page.dart
+++ b/lib/expenses_page.dart
@@ -57,7 +57,7 @@ class ExpensesPageState extends State<ExpensesPage> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 const Text(
-                  'Yeni harcama',
+                  'New expense',
                   style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
                   textAlign: TextAlign.center,
                 ),
@@ -65,25 +65,26 @@ class ExpensesPageState extends State<ExpensesPage> {
                 TextFormField(
                   controller: descCtrl,
                   decoration: const InputDecoration(
-                    labelText: 'Açıklama',
-                    hintText: 'Örn. Bulaşık deterjanı',
+                    labelText: 'Description',
+                    hintText: 'e.g. Dish soap',
                     border: OutlineInputBorder(),
                   ),
                   textCapitalization: TextCapitalization.sentences,
-                  validator: (v) => (v == null || v.trim().isEmpty) ? 'Açıklama zorunlu' : null,
+                  validator: (v) =>
+                      (v == null || v.trim().isEmpty) ? 'Description is required' : null,
                 ),
                 const SizedBox(height: 12),
                 TextFormField(
                   controller: priceCtrl,
                   keyboardType: const TextInputType.numberWithOptions(decimal: true),
                   decoration: const InputDecoration(
-                    labelText: 'Tutar (₺)',
+                    labelText: 'Amount (₺)',
                     border: OutlineInputBorder(),
                   ),
                   validator: (v) {
-                    if (v == null || v.trim().isEmpty) return 'Tutar zorunlu';
+                    if (v == null || v.trim().isEmpty) return 'Amount is required';
                     final amount = double.tryParse(v.replaceAll(',', '.'));
-                    if (amount == null || amount <= 0) return 'Geçerli bir tutar gir';
+                    if (amount == null || amount <= 0) return 'Enter a valid amount';
                     return null;
                   },
                 ),
@@ -91,14 +92,14 @@ class ExpensesPageState extends State<ExpensesPage> {
                 DropdownButtonFormField<int>(
                   value: buyerRoom,
                   items: widget.roomNumbers.map((room) {
-                    return DropdownMenuItem(value: room, child: Text('Oda $room'));
+                    return DropdownMenuItem(value: room, child: Text('Room $room'));
                   }).toList(),
                   onChanged: (v) => buyerRoom = v,
                   decoration: const InputDecoration(
-                    labelText: 'Kim aldı? (Oda)',
+                    labelText: 'Who bought it? (Room)',
                     border: OutlineInputBorder(),
                   ),
-                  validator: (v) => v == null ? 'Oda seç' : null,
+                  validator: (v) => v == null ? 'Select a room' : null,
                 ),
                 const SizedBox(height: 16),
                 FilledButton.icon(
@@ -119,7 +120,7 @@ class ExpensesPageState extends State<ExpensesPage> {
                     if (mounted) Navigator.pop(ctx);
                   },
                   icon: const Icon(Icons.save),
-                  label: const Text('Kaydet'),
+                  label: const Text('Save'),
                 ),
               ],
             ),
@@ -133,11 +134,11 @@ class ExpensesPageState extends State<ExpensesPage> {
     final ok = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Silinsin mi?'),
-        content: const Text('Bu harcamayı silmek istediğine emin misin?'),
+        title: const Text('Delete this expense?'),
+        content: const Text('Are you sure you want to delete this expense?'),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Vazgeç')),
-          FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Sil')),
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Delete')),
         ],
       ),
     );
@@ -173,14 +174,14 @@ class ExpensesPageState extends State<ExpensesPage> {
               children: [
                 Image.asset('assets/loogo.png', height: 28),
                 const SizedBox(width: 8),
-                const Text('Giderler'),
+                const Text('Expenses'),
               ],
             ),
           ),
           floatingActionButton: FloatingActionButton.extended(
             onPressed: _addExpenseDialog,
             icon: const Icon(Icons.add),
-            label: const Text('Harcama ekle'),
+            label: const Text('Add expense'),
           ),
           body: Padding(
             padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
@@ -196,7 +197,7 @@ class ExpensesPageState extends State<ExpensesPage> {
       stream: q.snapshots(),
       builder: (context, snap) {
         if (snap.hasError) {
-          return Center(child: Text('Hata: ${snap.error}'));
+          return Center(child: Text('Error: ${snap.error}'));
         }
         if (!snap.hasData) {
           return const Center(child: CircularProgressIndicator());
@@ -257,7 +258,7 @@ class ExpensesPageState extends State<ExpensesPage> {
                         IconButton(
                           icon: const Icon(Icons.delete_outline),
                           onPressed: () => _deleteExpense(doc.id),
-                          tooltip: 'Sil',
+                          tooltip: 'Delete',
                         ),
                       ],
                     ),
@@ -307,7 +308,7 @@ class _ExpensesSummary extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Toplam: ₺${grandTotal.toStringAsFixed(2)}',
+            Text('Total: ₺${grandTotal.toStringAsFixed(2)}',
                 style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
             const SizedBox(height: 8),
             Wrap(
@@ -316,7 +317,7 @@ class _ExpensesSummary extends StatelessWidget {
               children: visibleRooms.map((room) {
                 final amount = totalsByRoom[room] ?? 0;
                 return Chip(
-                  label: Text('Oda $room • ₺${amount.toStringAsFixed(0)}'),
+                  label: Text('Room $room • ₺${amount.toStringAsFixed(0)}'),
                 );
               }).toList(),
             ),
@@ -338,9 +339,9 @@ class _EmptyExpensesState extends StatelessWidget {
         children: const [
           Icon(Icons.receipt_long_outlined, size: 48),
           SizedBox(height: 12),
-          Text('Henüz harcama eklenmemiş.'),
+          Text('No expenses yet.'),
           SizedBox(height: 4),
-          Text('Sağ alttaki butonla ilk harcamanı kaydet.'),
+          Text('Use the button in the bottom-right to add your first expense.'),
         ],
       ),
     );

--- a/lib/history_page.dart
+++ b/lib/history_page.dart
@@ -71,7 +71,7 @@ class _HistoryList extends StatelessWidget {
       stream: query.snapshots(),
       builder: (context, snap) {
         if (snap.hasError) {
-          return Center(child: Text('Hata: ${snap.error}'));
+          return Center(child: Text('Error: ${snap.error}'));
         }
         if (!snap.hasData) {
           return const Center(child: CircularProgressIndicator());
@@ -79,7 +79,7 @@ class _HistoryList extends StatelessWidget {
 
         final docs = snap.data!.docs;
         if (docs.isEmpty) {
-          return const Center(child: Text('Henüz tarihçe yok.'));
+          return const Center(child: Text('No history yet.'));
         }
 
         return Card(
@@ -102,7 +102,7 @@ class _HistoryList extends StatelessWidget {
 
               return ListTile(
                 leading: _ProofThumb(url: proof),
-                title: Text('$task • Oda $room'),
+                title: Text('$task • Room $room'),
                 subtitle: Text([
                   if (by.isNotEmpty) by,
                   if (timeStr.isNotEmpty) timeStr,
@@ -123,7 +123,7 @@ class _HistoryList extends StatelessWidget {
                                       ),
                                 errorBuilder: (c, e, s) => const Padding(
                                   padding: EdgeInsets.all(24),
-                                  child: Text('Görsel yüklenemedi.'),
+                                  child: Text('Image failed to load.'),
                                 ),
                               ),
                             ),

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -41,9 +41,9 @@ class _LoginPageState extends State<LoginPage> {
         MaterialPageRoute(builder: (_) => const DashboardPage()),
       );
     } on FirebaseAuthException catch (e) {
-      _toast(e.message ?? 'Giriş başarısız.');
+      _toast(e.message ?? 'Login failed.');
     } catch (e) {
-      _toast('Giriş hatası: $e');
+      _toast('Login error: $e');
     } finally {
       if (mounted) setState(() => _loading = false);
     }
@@ -52,14 +52,14 @@ class _LoginPageState extends State<LoginPage> {
   Future<void> _resetPassword() async {
     final email = _email.text.trim();
     if (email.isEmpty) {
-      _toast('Şifre sıfırlamak için email gir.');
+      _toast('Enter your email to reset the password.');
       return;
     }
     try {
       await _auth.sendPasswordResetEmail(email: email);
-      _toast('Sıfırlama maili gönderildi.');
+      _toast('Password reset email sent.');
     } on FirebaseAuthException catch (e) {
-      _toast(e.message ?? 'Sıfırlama başarısız.');
+      _toast(e.message ?? 'Password reset failed.');
     }
   }
 
@@ -85,7 +85,7 @@ class _LoginPageState extends State<LoginPage> {
               ),
               const SizedBox(height: 12),
               Text(
-                'Tekrar hoş geldin 👋',
+                'Welcome back 👋',
                 style: Theme.of(context)
                     .textTheme
                     .headlineSmall
@@ -103,10 +103,10 @@ class _LoginPageState extends State<LoginPage> {
                 validator: (value) {
                   final text = value?.trim() ?? '';
                   if (text.isEmpty) {
-                    return 'Email gerekli';
+                    return 'Email is required';
                   }
                   if (!text.contains('@') || !text.contains('.')) {
-                    return 'Geçerli bir email gir';
+                    return 'Enter a valid email';
                   }
                   return null;
                 },
@@ -123,10 +123,10 @@ class _LoginPageState extends State<LoginPage> {
                 validator: (value) {
                   final text = value ?? '';
                   if (text.isEmpty) {
-                    return 'Şifre gerekli';
+                    return 'Password is required';
                   }
                   if (text.length < 6) {
-                    return 'Şifre en az 6 karakter olmalı';
+                    return 'Password must be at least 6 characters';
                   }
                   return null;
                 },
@@ -144,7 +144,7 @@ class _LoginPageState extends State<LoginPage> {
                 alignment: Alignment.centerRight,
                 child: TextButton(
                   onPressed: _loading ? null : _resetPassword,
-                  child: const Text('Şifremi unuttum'),
+                  child: const Text('Forgot password?'),
                 ),
               ),
               const SizedBox(height: 6),
@@ -158,14 +158,14 @@ class _LoginPageState extends State<LoginPage> {
                           height: 22,
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
-                      : const Text('Giriş yap'),
+                      : const Text('Sign in'),
                 ),
               ),
               const SizedBox(height: 18),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Text('Hesabın yok mu? '),
+                  const Text('Don’t have an account? '),
                   TextButton(
                     onPressed: _loading
                         ? null
@@ -173,7 +173,7 @@ class _LoginPageState extends State<LoginPage> {
                               MaterialPageRoute(
                                   builder: (_) => const RegisterPage()),
                             ),
-                    child: const Text('Hemen kaydol'),
+                    child: const Text('Sign up now'),
                   ),
                 ],
               ),

--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -58,7 +58,7 @@ class _RegisterPageState extends State<RegisterPage> {
         final List members = List.from(data['members'] ?? []);
         final taken = members.any((m) => (m['roomNumber'] as num?)?.toInt() == _roomNo);
         if (taken) {
-          throw Exception('Seçtiğin oda dolu.');
+          throw Exception('That room is already taken.');
         }
 
         tx.set(_fs.collection('users').doc(uid), {
@@ -90,7 +90,7 @@ class _RegisterPageState extends State<RegisterPage> {
         (_) => false,
       );
     } on FirebaseAuthException catch (e) {
-      _toast(e.message ?? 'Kayıt başarısız.');
+      _toast(e.message ?? 'Registration failed.');
     } catch (e) {
       _toast(e.toString());
     } finally {
@@ -114,7 +114,7 @@ class _RegisterPageState extends State<RegisterPage> {
               Center(child: Image.asset('assets/loogo.png', height: 88)),
               const SizedBox(height: 12),
               Text(
-                'Yeni FlatMate hesabı oluştur',
+                'Create a new FlatMate account',
                 style: Theme.of(context)
                     .textTheme
                     .headlineSmall
@@ -124,13 +124,13 @@ class _RegisterPageState extends State<RegisterPage> {
               const SizedBox(height: 24),
               _frostedField(
                 controller: _name,
-                label: 'Ad soyad',
+                label: 'Full name',
                 icon: Icons.person_outline,
                 textInputAction: TextInputAction.next,
                 autofillHints: const [AutofillHints.name],
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
-                    return 'İsim gerekli';
+                    return 'Name is required';
                   }
                   return null;
                 },
@@ -146,10 +146,10 @@ class _RegisterPageState extends State<RegisterPage> {
                 validator: (value) {
                   final text = value?.trim() ?? '';
                   if (text.isEmpty) {
-                    return 'Email gerekli';
+                    return 'Email is required';
                   }
                   if (!text.contains('@') || !text.contains('.')) {
-                    return 'Geçerli bir email gir';
+                    return 'Enter a valid email';
                   }
                   return null;
                 },
@@ -157,7 +157,7 @@ class _RegisterPageState extends State<RegisterPage> {
               const SizedBox(height: 14),
               _frostedField(
                 controller: _password,
-                label: 'Şifre',
+                label: 'Password',
                 icon: Icons.lock_outline,
                 obscure: _obscure,
                 textInputAction: TextInputAction.next,
@@ -165,10 +165,10 @@ class _RegisterPageState extends State<RegisterPage> {
                 validator: (value) {
                   final text = value ?? '';
                   if (text.isEmpty) {
-                    return 'Şifre gerekli';
+                    return 'Password is required';
                   }
                   if (text.length < 6) {
-                    return 'Şifre en az 6 karakter olmalı';
+                    return 'Password must be at least 6 characters';
                   }
                   return null;
                 },
@@ -190,13 +190,13 @@ class _RegisterPageState extends State<RegisterPage> {
                           height: 22,
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
-                      : const Text('Kaydı tamamla'),
+                      : const Text('Complete signup'),
                 ),
               ),
               const SizedBox(height: 12),
               TextButton(
                 onPressed: _loading ? null : () => Navigator.pop(context),
-                child: const Text('Zaten hesabım var'),
+                child: const Text('I already have an account'),
               ),
             ],
           ),
@@ -208,7 +208,7 @@ class _RegisterPageState extends State<RegisterPage> {
   Widget _roomSelector() {
     final items = List.generate(20, (i) => i + 1);
     return FormField<int>(
-      validator: (_) => _roomNo == null ? 'Oda seçmelisin' : null,
+      validator: (_) => _roomNo == null ? 'You must select a room' : null,
       builder: (state) {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -227,13 +227,13 @@ class _RegisterPageState extends State<RegisterPage> {
                   dropdownColor: const Color(0xFF2B2A49),
                   iconEnabledColor: Colors.white70,
                   hint: Text(
-                    'Oda numarası seç',
+                    'Select a room number',
                     style: TextStyle(color: Colors.white.withOpacity(0.72)),
                   ),
                   items: items
                       .map((n) => DropdownMenuItem(
                             value: n,
-                            child: Text('Oda $n', style: const TextStyle(color: Colors.white)),
+                            child: Text('Room $n', style: const TextStyle(color: Colors.white)),
                           ))
                       .toList(),
                   onChanged: (v) {


### PR DESCRIPTION
### Motivation
- The app UI contained Turkish strings across multiple pages, which should be presented in English for wider readability.
- Inline comments in `lib/bootstrap.dart` were also written in Turkish and needed to be converted to English for clarity.

### Description
- Translated UI text, labels, hints, validation messages and tooltips from Turkish to English in `lib/login_page.dart`, `lib/register_page.dart`, `lib/dashboard_page.dart`, `lib/expenses_page.dart`, and `lib/history_page.dart`.
- Updated dialog titles, button labels and snack messages to English and adjusted some user-facing wording (e.g. `Yeni harcama` → `New expense`, `Giriş yap` → `Sign in`).
- Rewrote Turkish comments in `lib/bootstrap.dart` into English to describe bootstrap steps.
- Minor string formatting changes where room labels and summaries used Turkish words (e.g. `Oda` → `Room`, `Toplam` → `Total`).

### Testing
- No unit or integration tests were executed as part of this change.
- Performed an automated repository search using `rg` for Turkish characters to confirm no remaining Turkish strings were present, which returned no matches.
- Verified the changes were staged and committed successfully (`git commit`).
- No runtime verification (app run) was performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695193107350832fbc49708f638eb9d4)